### PR TITLE
Update dependencies in control file

### DIFF
--- a/Layout/DEBIAN/control
+++ b/Layout/DEBIAN/control
@@ -6,4 +6,4 @@ Description: Use your iPhone to register your Beeper Mini's phone number with Ap
 Maintainer: James Gill, June Welker
 Author: James Gill, June Welker
 Section: Tweaks
-Depends:
+Depends: mobilesubstrate, firmware (>= 10.0)


### PR DESCRIPTION
Some jailbreaks do not ship with a hooking library installed, and rely on it to be installed when needed (through a dependency from a tweak). Since `mobilesubstrate` isn't listed as a dependency, the tweak will install on these jailbreaks, but if a hooking library was not previously installed, the tweak will just not work. Adding the dependency fixes the issue. (Note that all hooking libraries provide `mobilesubstrate`, so no matter what hooking library is used dependency resolution will work properly).

I also added a firmware >= 10.0 restriction as stated in the README. 