### PR TITLE
Build for arm64e and use older Xcode version when not packaging for rootless

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   theos:
-    runs-on: macos-13
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,8 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-  theos:
-    runs-on: macos-11
+  theos-rootless:
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4
@@ -16,11 +16,33 @@ jobs:
 
       - name: Build package
         run: |
+          export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
           export PACKAGE_BUILDNAME=$(git rev-parse --short HEAD)-rootless
           make clean package THEOS_PACKAGE_SCHEME=rootless FINALPACKAGE=1
+
+      - name: Upload package
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./packages/com.beeper.beepserv_*.deb
+          name: phone-registration-provider
+          if-no-files-found: error
+  theos-rootful:
+    runs-on: macos-11
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+    
+      - name: Set up Theos
+        uses: Randomblock1/theos-action@v1
+    
+      - name: Build package
+        run: |
+          export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
           export PACKAGE_BUILDNAME=$(git rev-parse --short HEAD)-rootful
           make clean package FINALPACKAGE=1
-
+    
       - name: Upload package
         uses: actions/upload-artifact@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ARCHS = arm64 arm64e
 ifeq ($(THEOS_PACKAGE_SCHEME), rootless)
 	TARGET := iphone:clang:latest:15.0
 else
-	OLDER_XCODE_PATH=/Applications/Xcode-11.7.app
+	OLDER_XCODE_PATH=/Applications/Xcode_11.7.app
 	PREFIX=$(OLDER_XCODE_PATH)/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/
 	SYSROOT=$(OLDER_XCODE_PATH)/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
 	SDKVERSION = 13.7

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-TARGET := iphone:clang:latest:16.0
+ARCHS = arm64 arm64e
 
-THEOS_PACKAGE_SCHEME = rootless
-ARCHS = arm64
+ifeq ($(THEOS_PACKAGE_SCHEME), rootless)
+	TARGET := iphone:clang:latest:16.0
+else
+	OLDER_XCODE_PATH=/Applications/Xcode-11.7.app
+	PREFIX=$(OLDER_XCODE_PATH)/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/
+	SYSROOT=$(OLDER_XCODE_PATH)/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+	SDKVERSION = 13.7
+endif
 
 include $(THEOS)/makefiles/common.mk
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ARCHS = arm64 arm64e
 
 ifeq ($(THEOS_PACKAGE_SCHEME), rootless)
-	TARGET := iphone:clang:latest:16.0
+	TARGET := iphone:clang:latest:15.0
 else
 	OLDER_XCODE_PATH=/Applications/Xcode-11.7.app
 	PREFIX=$(OLDER_XCODE_PATH)/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ If this code does not appear, SSH into the iPhone and run `cat /var/jb/var/mobil
 2. Make sure you have ssh access to root on your device (the default password is `alpine`, you may need to log in to `mobile` over ssh first to change the password)
 3. Install [theos](https://theos.dev)
 4. Set the environment variable `$THEOS_DEVICE_IP` to the IP Address of the device you want to install it to (e.g. with `export THEOS_DEVICE_IP=<IP of phone>`)
-5. Optional: install oslog (not the default one, but specifically [the one from noisyflake](https://github.com/NoisyFlake/oslog), as it works on the latest versions of iOS) to watch logs from ssh
-6. Install with `make package install`
+5. Set the environment variable `$THEOS_PACKAGE_SCHEME` to `rootless` if you're using a rootless jailbreak (e.g. with `export THEOS_PACKAGE_SCHEME=rootless`)
+6. Optional: install oslog (not the default one, but specifically [the one from noisyflake](https://github.com/NoisyFlake/oslog), as it works on the latest versions of iOS) to watch logs from ssh
+7. Install with `make package install`
 
 ## Collaboration
 We are very interested in working with jailbreak developers to help improve this! Please join us in #beepserv:beeper.com Matrix channel. 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ If this code does not appear, SSH into the iPhone and run `cat /var/jb/var/mobil
 6. Optional: install oslog (not the default one, but specifically [the one from noisyflake](https://github.com/NoisyFlake/oslog), as it works on the latest versions of iOS) to watch logs from ssh
 7. Install with `make package install`
 
+The Makefiles currently assume you have Xcode 11.7 installed at `/Applications/Xcode_11.7.app` when not packaging for rootless to ensure compatibility with A12+ devices on iOS 12.0-13.7 ([more here](https://theos.dev/docs/arm64e-deployment)). You can either download this version from Apple or edit the Makefiles if you want to build with a different version.
+
 ## Collaboration
 We are very interested in working with jailbreak developers to help improve this! Please join us in #beepserv:beeper.com Matrix channel. 
 In particular, we would love some help converting this from being a tweak (with very complex UI that only shows up in Settings -> Messages) to being a normal app that shows up on home screen with UI to show logs etc.


### PR DESCRIPTION
For this tweak to work on A12 devices and up, `arm64e` needs to be added to the list of architectures.

It also seems like making this tweak work on some configurations requires changing the deployment target because, at least for me, the Settings app will crash when injecting a tweak with a deployment target of iOS 16, while a deployment target of iOS 15 works fine.

(On another note, when building with a deployment target of iOS 16 and `FINALPACKAGE=1`, the tweak does not seem to do anything at all, while iOS 15 and `FINALPACKAGE=1` works, so it might be worth looking into that?)

(I'm using a 2018 iPad Pro with iOS 14.5 for development)

The two above mentioned changes make the tweak run on my iPad, but it will still not work on A12+ devices running iOS 12.0-13.7 because of ABI changes. To support these devices, the tweak needs to be built with an Xcode version lower than 12 ([more here](https://theos.dev/docs/arm64e-deployment)).

I've added a condition to the Makefile that will use `/Applications/Xcode-11.7.app` when not packaging for rootless.