### PR TITLE
Use NSDistributedNotificationCenter to send state to Settings app

### DIFF
--- a/Constants.h
+++ b/Constants.h
@@ -1,0 +1,9 @@
+static NSString *kSuiteName = @"com.beeper.beepserv";
+
+static const NSString *kCode = @"com.beepserv.code";
+static const NSString *kSecret = @"com.beepserv.secret";
+static const NSString *kConnected = @"com.beepserv.connected";
+static const NSString *kError = @"com.beepserv.error";
+
+static const NSString *kNotificationRequestStateUpdate = @"com.beeper.beepserv/requestStateUpdate";
+static const NSString *kNotificationUpdateState = @"com.beeper.beepserv/updateState";

--- a/NSDistributedNotificationCenter.h
+++ b/NSDistributedNotificationCenter.h
@@ -1,0 +1,18 @@
+@interface NSDistributedNotificationCenter : NSNotificationCenter
+@property (assign) BOOL suspended;
++ (id)defaultCenter;
++ (id)notificationCenterForType:(id)arg1 ;
+- (id)init;
+- (void)removeObserver:(id)arg1 name:(id)arg2 object:(id)arg3 ;
+- (void)postNotificationName:(id)arg1 object:(id)arg2 userInfo:(id)arg3 ;
+- (void)addObserver:(id)arg1 selector:(SEL)arg2 name:(id)arg3 object:(id)arg4 ;
+- (void)postNotification:(id)arg1 ;
+- (void)postNotificationName:(id)arg1 object:(id)arg2 ;
+- (id)addObserverForName:(id)arg1 object:(id)arg2 queue:(id)arg3 usingBlock:(/*^block*/id)arg4 ;
+- (void)addObserver:(id)arg1 selector:(SEL)arg2 name:(id)arg3 object:(id)arg4 suspensionBehavior:(unsigned long long)arg5 ;
+- (id)addObserverForName:(id)arg1 object:(id)arg2 suspensionBehavior:(unsigned long long)arg3 queue:(id)arg4 usingBlock:(/*^block*/id)arg5 ;
+- (void)postNotificationName:(id)arg1 object:(id)arg2 userInfo:(id)arg3 options:(unsigned long long)arg4 ;
+- (void)postNotificationName:(id)arg1 object:(id)arg2 userInfo:(id)arg3 deliverImmediately:(BOOL)arg4 ;
+- (void)setSuspended:(BOOL)arg1 ;
+- (BOOL)suspended;
+@end

--- a/State.h
+++ b/State.h
@@ -1,7 +1,3 @@
-#import <Foundation/Foundation.h>
-#import "NSDistributedNotificationCenter.h"
-#import "Constants.h"
-
 @interface BPState: NSObject
 @property (nonatomic, strong, nullable) NSString *code;
 @property (nonatomic, strong, nullable) NSString *secret;

--- a/State.h
+++ b/State.h
@@ -13,6 +13,7 @@
 				             connected:(BOOL)connected
 				                 error:(NSError * __nullable)error;
 
+- (NSDictionary * __nonnull)serializeToDictionary;
 - (void)broadcast;
 - (void)writeToDiskWithError:(NSError * __nullable * __nullable)writeErr;
 

--- a/State.h
+++ b/State.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import "NSDistributedNotificationCenter.h"
 
 @interface BPState: NSObject
 @property (nonatomic, strong, nullable) NSString *code;
@@ -12,6 +13,7 @@
 				             connected:(BOOL)connected
 				                 error:(NSError * __nullable)error;
 
+- (void)broadcast;
 - (void)writeToDiskWithError:(NSError * __nullable * __nullable)writeErr;
 
 // if this returns nil but the error isn't set, that means the file just doesn't exist

--- a/State.h
+++ b/State.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "NSDistributedNotificationCenter.h"
+#import "Constants.h"
 
 @interface BPState: NSObject
 @property (nonatomic, strong, nullable) NSString *code;

--- a/State.x
+++ b/State.x
@@ -26,7 +26,7 @@ static NSString *otherStateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
 	return [NSString stringWithFormat:@"<BPState code:%@ secret:%@ connected:%d error:%@", self.code, self.secret, self.connected, self.error];
 }
 
-- (void)broadcast {
+- (NSDictionary * __nonnull)serializeToDictionary {
 	NSMutableDictionary *state = @{
 		kConnected: @(self.connected)
 	}.mutableCopy;
@@ -40,6 +40,12 @@ static NSString *otherStateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
 	if (self.error)
 		state[kError] = self.error;
 		
+	return state;
+}
+
+- (void)broadcast {
+	NSDictionary *state = [self serializeToDictionary];
+		
 	[[NSDistributedNotificationCenter defaultCenter]
 		postNotificationName: @"com.beeper.beepserv/updateState"
 		object: nil
@@ -48,18 +54,7 @@ static NSString *otherStateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
 }
 
 - (void)writeToDiskWithError:(NSError * __nullable * __nullable)writeErr {
-	NSMutableDictionary *state = @{
-		kConnected: @(self.connected)
-	}.mutableCopy;
-
-	if (self.code)
-		state[kCode] = self.code;
-
-	if (self.secret)
-		state[kSecret] = self.secret;
-
-	if (self.error)
-		state[kError] = self.error;
+	NSDictionary *state = [self serializeToDictionary];
 
 	NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"file://%@", stateFile]];
 	[state writeToURL:url error:writeErr];

--- a/State.x
+++ b/State.x
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 #import <rootless.h>
 #import "State.h"
+#import "NSDistributedNotificationCenter.h"
+#import "Constants.h"
 
 static NSString *stateFile = ROOT_PATH_NS(@"/var/mobile/Library/.beepserv_state");
 static NSString *otherStateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");

--- a/State.x
+++ b/State.x
@@ -6,7 +6,8 @@ static NSString *kCode = @"com.beepserv.code";
 static NSString *kSecret = @"com.beepserv.secret";
 static NSString *kConnected = @"com.beepserv.connected";
 static NSString *kError = @"com.beepserv.error";
-static NSString *stateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
+static NSString *stateFile = ROOT_PATH_NS(@"/var/mobile/Library/.beepserv_state");
+static NSString *otherStateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
 
 @implementation BPState
 - (instancetype __nonnull)initWithCode:(NSString * __nullable)code
@@ -25,6 +26,27 @@ static NSString *stateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
 	return [NSString stringWithFormat:@"<BPState code:%@ secret:%@ connected:%d error:%@", self.code, self.secret, self.connected, self.error];
 }
 
+- (void)broadcast {
+	NSMutableDictionary *state = @{
+		kConnected: @(self.connected)
+	}.mutableCopy;
+	
+	if (self.code)
+		state[kCode] = self.code;
+	
+	if (self.secret)
+		state[kSecret] = self.secret;
+	
+	if (self.error)
+		state[kError] = self.error;
+		
+	[[NSDistributedNotificationCenter defaultCenter]
+		postNotificationName: @"com.beeper.beepserv/updateState"
+		object: nil
+		userInfo: state
+	];
+}
+
 - (void)writeToDiskWithError:(NSError * __nullable * __nullable)writeErr {
 	NSMutableDictionary *state = @{
 		kConnected: @(self.connected)
@@ -41,6 +63,8 @@ static NSString *stateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
 
 	NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"file://%@", stateFile]];
 	[state writeToURL:url error:writeErr];
+	NSURL *otherUrl = [NSURL URLWithString:[NSString stringWithFormat:@"file://%@", otherStateFile]];
+	[state writeToURL:otherUrl error:writeErr];
 }
 
 + (instancetype __nullable)readFromDiskWithError:(NSError * __nullable * __nullable)readErr {
@@ -50,8 +74,15 @@ static NSString *stateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
 	NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"file://%@", stateFile]];
 	NSDictionary *state = [NSDictionary dictionaryWithContentsOfURL:url error:readErr];
 
-	if (readErr && *readErr)
-		return nil;
+	if (readErr && *readErr) {
+		NSError *otherReadErr;
+		url = [NSURL URLWithString:[NSString stringWithFormat:@"file://%@", otherReadErr]];
+		state = [NSDictionary dictionaryWithContentsOfURL:url error:&otherReadErr];
+		if (otherReadErr) {
+			*readErr = otherReadErr;
+			return nil;
+		}
+	}
 
 	BOOL connected = ((NSNumber *)state[kConnected]).boolValue;
 	return [BPState.alloc initWithCode:state[kCode] secret:state[kSecret] connected:connected error:state[kError]];

--- a/State.x
+++ b/State.x
@@ -2,10 +2,6 @@
 #import <rootless.h>
 #import "State.h"
 
-static NSString *kCode = @"com.beepserv.code";
-static NSString *kSecret = @"com.beepserv.secret";
-static NSString *kConnected = @"com.beepserv.connected";
-static NSString *kError = @"com.beepserv.error";
 static NSString *stateFile = ROOT_PATH_NS(@"/var/mobile/Library/.beepserv_state");
 static NSString *otherStateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
 
@@ -47,7 +43,7 @@ static NSString *otherStateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
 	NSDictionary *state = [self serializeToDictionary];
 		
 	[[NSDistributedNotificationCenter defaultCenter]
-		postNotificationName: @"com.beeper.beepserv/updateState"
+		postNotificationName: kNotificationUpdateState
 		object: nil
 		userInfo: state
 	];

--- a/Tweak.h
+++ b/Tweak.h
@@ -1,3 +1,5 @@
+#import "NSDistributedNotificationCenter.h"
+
 @interface IDSValidationSession : NSObject
 - (NSDictionary * __nonnull)headersBySigningData:(NSData * __nonnull)data serverTimestamp:(int)ts error:(NSError * __nullable * __nullable)error;
 @end

--- a/Tweak.h
+++ b/Tweak.h
@@ -1,6 +1,3 @@
-#import "NSDistributedNotificationCenter.h"
-#import "Constants.h"
-
 @interface IDSValidationSession : NSObject
 - (NSDictionary * __nonnull)headersBySigningData:(NSData * __nonnull)data serverTimestamp:(int)ts error:(NSError * __nullable * __nullable)error;
 @end

--- a/Tweak.h
+++ b/Tweak.h
@@ -1,4 +1,5 @@
 #import "NSDistributedNotificationCenter.h"
+#import "Constants.h"
 
 @interface IDSValidationSession : NSObject
 - (NSDictionary * __nonnull)headersBySigningData:(NSData * __nonnull)data serverTimestamp:(int)ts error:(NSError * __nullable * __nullable)error;

--- a/Tweak.x
+++ b/Tweak.x
@@ -237,7 +237,7 @@ void log_impl(NSString *logStr) {
                       secret:(NSString * __nullable)secret
 				   connected:(BOOL)connected
 				       error:(NSError * __nullable)error {
-	currentState = [BPState.alloc initWithCode:code secret:secret connected:connected error:nil];
+	currentState = [BPState.alloc initWithCode:code secret:secret connected:connected error:error];
 	
 	[currentState broadcast];
 	

--- a/Tweak.x
+++ b/Tweak.x
@@ -1,10 +1,12 @@
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
 #import <sys/sysctl.h>
+#import <rootless.h>
 #import "SRWebSocket.h"
 #import "Tweak.h"
 #import "State.h"
-#import <rootless.h>
+#import "NSDistributedNotificationCenter.h"
+#import "Constants.h"
 
 #define LOG(...) log_impl([NSString stringWithFormat:__VA_ARGS__])
 

--- a/Tweak.x
+++ b/Tweak.x
@@ -26,8 +26,6 @@ static dispatch_semaphore_t validationDataCompletion;
 // The identifiers for this device/os/etc
 static NSDictionary *identifiers;
 
-static NSString *kSuiteName = @"com.beeper.beepserv";
-
 void log_impl(NSString *logStr) {
 	NSLog(@"BPS: %@", [logStr stringByReplacingOccurrencesOfString:@"\n" withString:@" "]);
 	NSString *logFile = ROOT_PATH_NS(@"/var/mobile/beepserv.log");
@@ -420,14 +418,14 @@ NSDictionary *getIdentifiers() {
 	// This %ctor will be called every time identityservicesd or the settings app is restarted.
 	// So we only want it to try to reinitialize stuff if it's in identityservicesd
 	if (![bundleID isEqualToString:@"com.apple.identityservicesd"]) {
-		[[NSDistributedNotificationCenter defaultCenter] addObserverForName: @"com.beeper.beepserv/updateState"
+		[[NSDistributedNotificationCenter defaultCenter] addObserverForName: kNotificationUpdateState
 			object: nil
 			queue: [NSOperationQueue mainQueue]
 			usingBlock: ^(NSNotification *notification)
 		{
 			NSDictionary *state = notification.userInfo;
 			LOG(@"Received broadcasted state: %@", state);
-			currentState = [BPState.alloc initWithCode:[state valueForKey: @"com.beepserv.code"] secret:[state valueForKey: @"com.beepserv.secret"] connected:[state valueForKey: @"com.beepserv.connected"] error:[state valueForKey: @"com.beepserv.error"]];
+			currentState = [BPState.alloc initWithCode:state[kCode] secret:state[kSecret] connected:((NSNumber *)state[kConnected]).boolValue error:state[kError]];
 			NSError *diskWriteError;
 			[currentState writeToDiskWithError:&diskWriteError];
 			if (diskWriteError != nil) {
@@ -435,14 +433,14 @@ NSDictionary *getIdentifiers() {
 			}
 		}];
 		[[NSDistributedNotificationCenter defaultCenter]
-			postNotificationName: @"com.beeper.beepserv/requestStateUpdate"
+			postNotificationName: kNotificationRequestStateUpdate
 			object: nil
 			userInfo: nil
 		];
 		return;
 	}
 	
-	[[NSDistributedNotificationCenter defaultCenter] addObserverForName: @"com.beeper.beepserv/requestStateUpdate"
+	[[NSDistributedNotificationCenter defaultCenter] addObserverForName: kNotificationRequestStateUpdate
 		object: nil
 		queue: [NSOperationQueue mainQueue]
 		usingBlock: ^(NSNotification *notification)

--- a/Tweak.x
+++ b/Tweak.x
@@ -11,6 +11,9 @@
 // cheap globals 'cause IPC is stupid and we'll figure it out later
 static NSError *currentError;
 
+// In identityservicesd, this stores the current state to be sent when requested by the Settings app.
+// The Settings app requests the state when it is opened and stores it here
+// to be used in the hook for the messages section footer text
 static BPState *currentState;
 
 // Store the validation data expiry timestamp (10 minutes from now)


### PR DESCRIPTION
I don't know if it's a problem with my specific device but writing to files like `/var/mobile/.beepserv_state` from `identityservicesd`  fails with `Operation not permitted`.

Also, reading from `/var/mobile/.beepserv_state` from the service fails but reading from `/var/mobile/Library/.beepserv_state` works.

(I'm using a 2018 iPad Pro with iOS 14.5, jailbroken via unc0ver, and using Substitute, for development)

Therefore, `NSDistributedNotificationCenter` is used to send the state from `identityservicesd` to the Settings app when the app is launched. Also, the state is written to and read from `/var/mobile/Library/.beepserv_state` in addition to `/var/mobile/.beepserv_state`.

I don't know whether this change makes sense, since it is a fairly big change for a problem where it's unclear how many people it affects, but I'd like to hear your thoughts.