### PR TITLE
Use different method of starting registration

### DIFF
--- a/Tweak.h
+++ b/Tweak.h
@@ -10,9 +10,16 @@
 @interface IDSRegistration : NSObject
 @end
 
+@interface IDSServiceProperties : NSObject
+	@property (nonatomic,retain) NSString * __nullable identifier;
+@end
+
 @interface IDSDAccount
+@property(readonly, nonatomic) IDSServiceProperties * __nullable service;
 - (id __nullable)_rebuildRegistrationInfo:(BOOL)rebuild;
 - (void)_checkRegistration;
+- (void)activateRegistration;
+- (void)reregister;
 - (void)setRegistrationStatus:(int)status error:(NSError * __nullable)error alertInfo:(id __nullable)alertInfo;
 - (IDSRegistration * __nullable)registration;
 @end


### PR DESCRIPTION
Instead of calling `-[IDSRegistrationCenter _sendAuthenticateRegistration:]`, we call `reregister` on the account, which should have similar effects but not require an account with a non-nil `registration` property.

If the `registration` property is nil, we also have to call `activateRegistration` before `reregister` to make it work.

I'm not sure whether this is really necessary, but we also make sure that the account is for `com.apple.madrid` (iMessage).

It now works with iMessage turned on or off in the device settings, whereas before it required iMessage to be turned on (while the registration code is not visible in Settings when iMessage is turned off, it can still be retrieved by looking through the logs).

I don't know whether this method has any drawbacks, but maybe this fixes #18?