### PR TITLE
Check for state file at both paths

### DIFF
--- a/State.x
+++ b/State.x
@@ -61,8 +61,12 @@ static NSString *otherStateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
 }
 
 + (instancetype __nullable)readFromDiskWithError:(NSError * __nullable * __nullable)readErr {
-	if (![NSFileManager.defaultManager fileExistsAtPath:stateFile isDirectory:nil])
+	if (
+		![NSFileManager.defaultManager fileExistsAtPath:stateFile isDirectory:nil] &&
+		![NSFileManager.defaultManager fileExistsAtPath:otherStateFile isDirectory:nil]
+	) {
 		return nil;
+	}
 
 	NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"file://%@", stateFile]];
 	NSDictionary *state = [NSDictionary dictionaryWithContentsOfURL:url error:readErr];

--- a/State.x
+++ b/State.x
@@ -73,7 +73,7 @@ static NSString *otherStateFile = ROOT_PATH_NS(@"/var/mobile/.beepserv_state");
 
 	if (readErr && *readErr) {
 		NSError *otherReadErr;
-		url = [NSURL URLWithString:[NSString stringWithFormat:@"file://%@", otherReadErr]];
+		url = [NSURL URLWithString:[NSString stringWithFormat:@"file://%@", otherStateFile]];
 		state = [NSDictionary dictionaryWithContentsOfURL:url error:&otherReadErr];
 		if (otherReadErr) {
 			*readErr = otherReadErr;


### PR DESCRIPTION
The changes from #16 made it so the state can be stored at both `/var/mobile/.beepserv_state` and `/var/mobile/Library/.beepserv_state`, however the file exists check was not updated to look at both paths, so users who only have `/var/mobile/.beepserv_state` are not able to load the state from disk.

This PR fixes this by extending the check to look for a file at either location.