### PR TITLE
Remove workaround for Logos bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If this code does not appear, SSH into the iPhone and run `cat /var/jb/var/mobil
 ## Building
 1. You need some hooking library installed on the target device, such as ellekit, libhooker, mobilesubstitute, or mobilesubstrate installed
 2. Make sure you have ssh access to root on your device (the default password is `alpine`, you may need to log in to `mobile` over ssh first to change the password)
-3. Install [theos](https://theos.dev)
+3. Install [theos](https://theos.dev) or make sure it's up-to-date by running `$THEOS/bin/update-theos` or `make update-theos`
 4. Set the environment variable `$THEOS_DEVICE_IP` to the IP Address of the device you want to install it to (e.g. with `export THEOS_DEVICE_IP=<IP of phone>`)
 5. Optional: install oslog (not the default one, but specifically [the one from noisyflake](https://github.com/NoisyFlake/oslog), as it works on the latest versions of iOS) to watch logs from ssh
 6. Install with `make package install`

--- a/Tweak.x
+++ b/Tweak.x
@@ -218,11 +218,8 @@ void log_impl(NSString *logStr) {
 	if (jsonErr)
 		LOG(@"Couldn't send dict %@, as it couldn't be serialized: %@", dict, jsonErr);
 
-	// so. for some incomprehensible reason, the precompiler for theos chokes when you include `{.*}`
-	// in a string literal, so we have to cheat and escape them by inserting their unicode codes as
-	// characters in format arguments
 	NSString *sendStr = (jsonErr != nil) ?
-		[NSString stringWithFormat:@"%C \"error\": \"Couldn't serialize to JSON: %@\" %C", 0x007b, jsonErr, 0x007b] :
+		[NSString stringWithFormat:@"{ \"error\": \"Couldn't serialize to JSON: %@\" }", jsonErr] :
 		[NSString.alloc initWithData:jsonData encoding:NSUTF8StringEncoding];
 
 	LOG(@"Sending string '%@'", sendStr);


### PR DESCRIPTION
According to #23, the bug in Logos regarding braces and quotes has been fixed by [this PR](https://github.com/theos/logos/pull/112).

Therefore, the workaround can be removed.

I've also added a note about updating Theos to the readme to make sure people don't run into issues when trying to build with an outdated version of Theos.